### PR TITLE
Dev/folders as tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+flickrannex.conf
+*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 0.1.7
+  - Allow directories to be used as tags (--directories-as-tags)
+    Directories below the top level git directory are added as tags to uploads:
+      /home/me/annex-photos/holidays/2013/Greenland/img001.jpg
+    would get the following tags:  "holidays" "2013" "Greenland"
+  - Fix minor typo
+
 # Version 0.1.6
   - Fix pagination error
   - Print certain error messages even with debug disabled.

--- a/README.md
+++ b/README.md
@@ -41,3 +41,12 @@ I might look into yyenc instead. I'm not sure if it will work in the tEXt field.
 
 Run the following command in your annex directory
    git annex content flickr exclude=largerthan=30mb
+
+## Including directories as tags
+Get get each of the directories below the top level git directory added as tags to uploads:
+   git config annex.flickr-hook 'GIT_TOP_LEVEL=`git rev-parse --show-toplevel` /usr/bin/python2 %s/flickrannex.py --directories-as-tags'
+
+In this case the image:
+   /home/me/annex-photos/holidays/2013/Greenland/img001.jpg
+would get the following tags:  "holidays" "2013" "Greenland"
+(assuming "/home/me/annex-photos" is the top level in the annex...)


### PR DESCRIPTION
Hi,

I've made a change to flickrannex to allow having directories as tags to uploads.

Directories below the top level git directory are added as tags to uploads:
    `/home/me/annex-photos/holidays/2013/Greenland/img001.jpg`
would get the following tags:  `holidays` `2013` `Greenland`
(where "/home/me/annex-photos" is the top level in the annex)

Hope you are happy to merge this change.

Olaf
