### PR TITLE
Handle indirect repos - set tags to empty.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ In this case the image:
 would get the following tags:  "holidays" "2013" "Greenland"
 (assuming "/home/me/annex-photos" is the top level in the annex...)
 
-Please note that this will only work properly for direct mode repositories.
+Caveat Emptor - Tags will *always* be NULL for indirect repos - we don't (easily) know the human-readable file name.

--- a/flickrannex.py
+++ b/flickrannex.py
@@ -112,6 +112,12 @@ def postFile(subject, filename, folder, git_top_level):
             else:
                 break
 
+        # Handle the case of indirect repos
+        #  - indirect repos have ".git" as the first subdirectory (never will happen for a direct repo)
+        #  - this will mean that don't know what the filename is in that case, so don't use any tags
+        if (len(tags) > 0) and (tags[len(tags) - 1] == ".git"):
+            tags = []
+
         common.log("Tags added to photo" + '"' + '" "'.join(tags) + '"')
 
     common.log("Uploading: " + tfile)


### PR DESCRIPTION
Hi Tobias,

Updated pull for the directories as tags fix for indirect repos.
